### PR TITLE
Minimum versions for Ignition dependencies

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -11,7 +11,7 @@ Build-Depends: cmake,
                libignition-common3-profiler-dev,
                libignition-math6-dev,
                libignition-math6-eigen3-dev,
-               libignition-plugin-dev,
+               libignition-plugin-dev (>= 1.1.0),
 # dart without major version number to get versions coming from Debian
                libdart6-dev (<< 6.10.0) | libdart-dev (<< 6.10.0),
                libdart6-collision-ode-dev (<< 6.10.0) | libdart-collision-ode-dev (<< 6.10.0),
@@ -29,7 +29,7 @@ Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-math6-dev,
-         libignition-plugin-dev,
+         libignition-plugin-dev (>= 1.1.0),
          libignition-physics2 (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -91,7 +91,7 @@ Depends: libignition-physics2-core-dev,
          libignition-common3-graphics-dev,
          libignition-math6-dev,
          libignition-math6-eigen3-dev,
-         libignition-plugin-dev,
+         libignition-plugin-dev (>= 1.1.0),
          libdart6-dev (<< 6.10.0) | libdart-dev (<< 6.10.0),
          libdart6-collision-ode-dev (<< 6.10.0) | libdart-collision-ode-dev (<< 6.10.0),
          libdart6-utils-dev (<< 6.10.0) | libdart-utils-dev (<< 6.10.0),


### PR DESCRIPTION
The main motivation is that right now, if a user only calls `sudo apt install libignition-physics2` to upgrade only this package, they end up with a broken system because the dependencies are not up-to-date.

I based myself on the versions currently required on [ign-physics's CMakeLists](https://github.com/ignitionrobotics/ign-physics/blob/ign-physics2/CMakeLists.txt), but we haven't been very good about updating these, so some could be out of date.