### PR TITLE
Install engine plugins on Focal

### DIFF
--- a/focal/debian/libignition-physics2-dartsim-dev.install
+++ b/focal/debian/libignition-physics2-dartsim-dev.install
@@ -1,4 +1,5 @@
 usr/include/ignition/physics*/ignition/physics/dartsim*/*
 usr/lib/*/cmake/ignition-physics[0-99]-dartsim*/*
 usr/lib/*/libignition-physics[0-99]-dartsim*.so
+usr/lib/*/ign-physics-[0-99]/engine-plugins/libignition-physics*-dartsim*.so
 usr/lib/*/pkgconfig/ignition-physics[0-99]-dartsim*.pc

--- a/focal/debian/libignition-physics2-dartsim.install
+++ b/focal/debian/libignition-physics2-dartsim.install
@@ -1,1 +1,2 @@
 usr/lib/*/libignition-physics[0-99]-dartsim*.so.*
+usr/lib/*/ign-physics-[0-99]/engine-plugins/libignition-physics*-dartsim*.so.*


### PR DESCRIPTION
Copying from the equivalent files on `/ubuntu`.

Right now `ign-gazebo` can't find DART at runtime on Focal.