### PR TITLE
TPE

### DIFF
--- a/focal/debian/control
+++ b/focal/debian/control
@@ -122,6 +122,66 @@ Description: Ignition Physics classes and functions for robot apps - Dartsim lib
   .
   DARTSim component shared library
 
+Package: libignition-physics2-tpe-dev
+Architecture: any
+Section: libdevel
+Depends: libignition-physics2-core-dev,
+         libignition-physics2-sdf-dev,
+         libignition-physics2-mesh-dev,
+         libignition-cmake2-dev,
+         libignition-math6-dev,
+         libignition-math6-eigen3-dev,
+         libignition-plugin-dev (>= 1.1.0),
+         libsdformat9-dev,
+         libignition-physics2-tpe (= ${binary:Version}),
+         ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Physics classes and functions for robot apps - Development files
+  Ignition Physics is a component in the ignition framework, a set of libraries
+  designed to rapidly develop robot applications.
+  .
+  TPE plugin component, development files
+
+Package: libignition-physics2-tpe
+Architecture: any
+Section: libs
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Physics classes and functions for robot apps - Dartsim library
+  Ignition Physics is a component in the ignition framework, a set of libraries
+  designed to rapidly develop robot applications.
+  .
+  TPE plugin component shared library
+
+Package: libignition-physics2-tpelib-dev
+Architecture: any
+Section: libdevel
+Depends: libignition-cmake2-dev,
+         libignition-math6-dev,
+         libignition-math6-eigen3-dev,
+         libignition-plugin-dev (>= 1.1.0),
+         libignition-physics2-tpelib (= ${binary:Version}),
+         ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Physics classes and functions for robot apps - Development files
+  Ignition Physics is a component in the ignition framework, a set of libraries
+  designed to rapidly develop robot applications.
+  .
+  TPE library component, development files
+
+Package: libignition-physics2-tpelib
+Architecture: any
+Section: libs
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Physics classes and functions for robot apps - Dartsim library
+  Ignition Physics is a component in the ignition framework, a set of libraries
+  designed to rapidly develop robot applications.
+  .
+  TPE library component shared library
+
 Package: libignition-physics2-dev
 Architecture: any
 Section: libdevel
@@ -129,6 +189,8 @@ Depends: libignition-physics2-core-dev,
          libignition-physics2-dartsim-dev,
          libignition-physics2-mesh-dev,
          libignition-physics2-sdf-dev,
+         libignition-physics2-tpe-dev,
+         libignition-physics2-tpelib-dev,
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Physics classes and functions for robot apps - Metapackage

--- a/focal/debian/libignition-physics2-tpe-dev.install
+++ b/focal/debian/libignition-physics2-tpe-dev.install
@@ -1,0 +1,1 @@
+../../ubuntu/debian/libignition-physics-tpe-dev.install

--- a/focal/debian/libignition-physics2-tpe.install
+++ b/focal/debian/libignition-physics2-tpe.install
@@ -1,0 +1,1 @@
+../../ubuntu/debian/libignition-physics-tpe.install

--- a/focal/debian/libignition-physics2-tpelib-dev.install
+++ b/focal/debian/libignition-physics2-tpelib-dev.install
@@ -1,0 +1,1 @@
+../../ubuntu/debian/libignition-physics-tpelib-dev.install

--- a/focal/debian/libignition-physics2-tpelib.install
+++ b/focal/debian/libignition-physics2-tpelib.install
@@ -1,0 +1,1 @@
+../../ubuntu/debian/libignition-physics-tpelib.install

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -121,6 +121,66 @@ Description: Ignition Physics classes and functions for robot apps - Dartsim lib
   .
   DARTSim component shared library
 
+Package: libignition-physics2-tpe-dev
+Architecture: any
+Section: libdevel
+Depends: libignition-physics2-core-dev,
+         libignition-physics2-sdf-dev,
+         libignition-physics2-mesh-dev,
+         libignition-cmake2-dev,
+         libignition-math6-dev,
+         libignition-math6-eigen3-dev,
+         libignition-plugin-dev (>= 1.1.0),
+         libsdformat9-dev,
+         libignition-physics2-tpe (= ${binary:Version}),
+         ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Physics classes and functions for robot apps - Development files
+  Ignition Physics is a component in the ignition framework, a set of libraries
+  designed to rapidly develop robot applications.
+  .
+  TPE plugin component, development files
+
+Package: libignition-physics2-tpe
+Architecture: any
+Section: libs
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Physics classes and functions for robot apps - Dartsim library
+  Ignition Physics is a component in the ignition framework, a set of libraries
+  designed to rapidly develop robot applications.
+  .
+  TPE plugin component shared library
+
+Package: libignition-physics2-tpelib-dev
+Architecture: any
+Section: libdevel
+Depends: libignition-cmake2-dev,
+         libignition-math6-dev,
+         libignition-math6-eigen3-dev,
+         libignition-plugin-dev (>= 1.1.0),
+         libignition-physics2-tpelib (= ${binary:Version}),
+         ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Physics classes and functions for robot apps - Development files
+  Ignition Physics is a component in the ignition framework, a set of libraries
+  designed to rapidly develop robot applications.
+  .
+  TPE library component, development files
+
+Package: libignition-physics2-tpelib
+Architecture: any
+Section: libs
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Physics classes and functions for robot apps - Dartsim library
+  Ignition Physics is a component in the ignition framework, a set of libraries
+  designed to rapidly develop robot applications.
+  .
+  TPE library component shared library
+
 Package: libignition-physics2-dev
 Architecture: any
 Section: libdevel
@@ -128,6 +188,8 @@ Depends: libignition-physics2-core-dev,
          libignition-physics2-dartsim-dev,
          libignition-physics2-mesh-dev,
          libignition-physics2-sdf-dev,
+         libignition-physics2-tpe-dev,
+         libignition-physics2-tpelib-dev,
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Physics classes and functions for robot apps - Metapackage

--- a/ubuntu/debian/libignition-physics-tpe-dev.install
+++ b/ubuntu/debian/libignition-physics-tpe-dev.install
@@ -1,0 +1,5 @@
+usr/include/ignition/physics*/ignition/physics/tpe-plugin/*
+usr/lib/*/cmake/ignition-physics[0-99]-tpe-plugin/*
+usr/lib/*/libignition-physics[0-99]-tpe-plugin.so
+usr/lib/*/ign-physics-[0-99]/engines/libignition-physics*-tpe-plugin.so
+usr/lib/*/pkgconfig/ignition-physics[0-99]-tpe-plugin.pc

--- a/ubuntu/debian/libignition-physics-tpe-dev.install
+++ b/ubuntu/debian/libignition-physics-tpe-dev.install
@@ -1,5 +1,7 @@
 usr/include/ignition/physics*/ignition/physics/tpe-plugin/*
 usr/lib/*/cmake/ignition-physics[0-99]-tpe-plugin/*
+usr/lib/*/cmake/ignition-physics[0-99]-tpe/*
 usr/lib/*/libignition-physics[0-99]-tpe-plugin.so
 usr/lib/*/ign-physics-[0-99]/engines/libignition-physics*-tpe-plugin.so
 usr/lib/*/pkgconfig/ignition-physics[0-99]-tpe-plugin.pc
+usr/lib/*/pkgconfig/ignition-physics[0-99]-tpe.pc

--- a/ubuntu/debian/libignition-physics-tpe-dev.install
+++ b/ubuntu/debian/libignition-physics-tpe-dev.install
@@ -1,5 +1,5 @@
 usr/include/ignition/physics*/ignition/physics/tpe-plugin/*
 usr/lib/*/cmake/ignition-physics[0-99]-tpe-plugin/*
 usr/lib/*/libignition-physics[0-99]-tpe-plugin.so
-usr/lib/*/ign-physics-[0-99]/engines/libignition-physics*-tpe-plugin.so
+usr/lib/*/ign-physics-[0-99]/engine-plugins/libignition-physics*-tpe-plugin.so
 usr/lib/*/pkgconfig/ignition-physics[0-99]-tpe-plugin.pc

--- a/ubuntu/debian/libignition-physics-tpe.install
+++ b/ubuntu/debian/libignition-physics-tpe.install
@@ -1,0 +1,2 @@
+usr/lib/*/libignition-physics[0-99]-tpe-plugin*.so.*
+usr/lib/*/ign-physics-[0-99]/engine-plugins/libignition-physics*-tpe-plugin*.so.*

--- a/ubuntu/debian/libignition-physics-tpelib-dev.install
+++ b/ubuntu/debian/libignition-physics-tpelib-dev.install
@@ -1,0 +1,4 @@
+usr/include/ignition/physics*/ignition/physics/tpelib/*
+usr/lib/*/cmake/ignition-physics[0-99]-tpelib/*
+usr/lib/*/libignition-physics[0-99]-tpelib.so
+usr/lib/*/pkgconfig/ignition-physics[0-99]-tpelib.pc

--- a/ubuntu/debian/libignition-physics-tpelib.install
+++ b/ubuntu/debian/libignition-physics-tpelib.install
@@ -1,0 +1,1 @@
+usr/lib/*/libignition-physics[0-99]-tpelib*.so.*


### PR DESCRIPTION
Closes #5 

These are the files I see on my colcon workspace:

<details><summary>Installed TPE files</summary>

```
install/include/ignition/physics2/ignition/physics/tpe-plugin
install/include/ignition/physics2/ignition/physics/tpe-plugin/Export.hh
install/include/ignition/physics2/ignition/physics/tpe-plugin/detail
install/include/ignition/physics2/ignition/physics/tpe-plugin/detail/Export.hh
install/include/ignition/physics2/ignition/physics/tpelib
install/include/ignition/physics2/ignition/physics/tpelib/Export.hh
install/include/ignition/physics2/ignition/physics/tpelib/detail
install/include/ignition/physics2/ignition/physics/tpelib/detail/Export.hh
install/lib/libignition-physics2-tpelib.so.2
install/lib/pkgconfig/ignition-physics2-tpelib.pc
install/lib/pkgconfig/ignition-physics2-tpe.pc
install/lib/pkgconfig/ignition-physics2-tpe-plugin.pc
install/lib/ign-physics-2/engine-plugins/libignition-physics-tpe-plugin.so
install/lib/ign-physics-2/engine-plugins/libignition-physics2-tpe-plugin.so.2.1.0
install/lib/ign-physics-2/engine-plugins/libignition-physics2-tpe-plugin.so.2
install/lib/ign-physics-2/engine-plugins/libignition-physics2-tpe-plugin.so
install/lib/libignition-physics2-tpe-plugin.so.2.1.0
install/lib/libignition-physics2-tpelib.so.2.1.0
install/lib/libignition-physics2-tpe-plugin.so.2
install/lib/cmake/ignition-physics2-tpe
install/lib/cmake/ignition-physics2-tpe/ignition-physics2-tpe-targets.cmake
install/lib/cmake/ignition-physics2-tpe/ignition-physics2-tpe-config.cmake
install/lib/cmake/ignition-physics2-tpe/ignition-physics2-tpe-config-version.cmake
install/lib/cmake/ignition-physics2-tpelib
install/lib/cmake/ignition-physics2-tpelib/ignition-physics2-tpelib-targets.cmake
install/lib/cmake/ignition-physics2-tpelib/ignition-physics2-tpelib-config-version.cmake
install/lib/cmake/ignition-physics2-tpelib/ignition-physics2-tpelib-config.cmake
install/lib/cmake/ignition-physics2-tpelib/ignition-physics2-tpelib-targets-relwithdebinfo.cmake
install/lib/cmake/ignition-physics2-tpe-plugin
install/lib/cmake/ignition-physics2-tpe-plugin/ignition-physics2-tpe-plugin-config-version.cmake
install/lib/cmake/ignition-physics2-tpe-plugin/ignition-physics2-tpe-plugin-targets-relwithdebinfo.cmake
install/lib/cmake/ignition-physics2-tpe-plugin/ignition-physics2-tpe-plugin-config.cmake
install/lib/cmake/ignition-physics2-tpe-plugin/ignition-physics2-tpe-plugin-targets.cmake
install/lib/libignition-physics2-tpe-plugin.so
install/lib/libignition-physics2-tpelib.so
```
</details>

There are 2 main libraries:

* `tpe-plugin`
* `tpelib`

Some files seem not to belong to either though:
* `install/lib/cmake/ignition-physics2-tpe/*`
* `install/lib/pkgconfig/ignition-physics2-tpe.pc`

So I haven't included them anywhere. I think `dartsim` is including the equivalent files on its side though. Maybe these should be added to `tpe-plugin`?